### PR TITLE
Remove @NotEmpty validation for boolean property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bin
 .rest-shell.log
 spring-shell.log
 gradle.properties
+/target/

--- a/src/main/java/org/cloudfoundry/community/servicebroker/model/ServiceDefinition.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/model/ServiceDefinition.java
@@ -35,7 +35,6 @@ public class ServiceDefinition {
 	@JsonProperty("description")
 	private String description;
 	
-	@NotEmpty
 	@JsonSerialize
 	@JsonProperty("bindable")
 	private boolean bindable;


### PR DESCRIPTION
You can't have @NotEmpty on a property of primitive type (it's not possible
for it to be null), so validation checks fail and crash without this change.
