### PR TITLE
Unbind and deprovision requests should return a 410 when entity is not found

### DIFF
--- a/src/main/java/org/cloudfoundry/community/servicebroker/controller/ServiceInstanceBindingController.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/controller/ServiceInstanceBindingController.java
@@ -89,7 +89,7 @@ public class ServiceInstanceBindingController extends BaseController {
 				+ ", planId = " + planId);
 		ServiceInstanceBinding binding = serviceInstanceBindingService.deleteServiceInstanceBinding(bindingId);
 		if (binding == null) {
-			return new ResponseEntity<String>("{}", HttpStatus.NOT_FOUND);
+			return new ResponseEntity<String>("{}", HttpStatus.GONE);
 		}
 		logger.debug("ServiceInstanceBinding Deleted: " + binding.getId());
         return new ResponseEntity<String>("{}", HttpStatus.OK);

--- a/src/main/java/org/cloudfoundry/community/servicebroker/controller/ServiceInstanceController.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/controller/ServiceInstanceController.java
@@ -92,7 +92,7 @@ public class ServiceInstanceController extends BaseController {
 				+ ", planId = " + planId);
 		ServiceInstance instance = service.deleteServiceInstance(instanceId);
 		if (instance == null) {
-			return new ResponseEntity<String>("{}", HttpStatus.NOT_FOUND);
+			return new ResponseEntity<String>("{}", HttpStatus.GONE);
 		}
 		logger.debug("ServiceInstance Deleted: " + instance.getId());
         return new ResponseEntity<String>("{}", HttpStatus.OK);

--- a/src/test/java/org/cloudfoundry/community/servicebroker/controller/ServiceInstanceBindingControllerIntegrationTest.java
+++ b/src/test/java/org/cloudfoundry/community/servicebroker/controller/ServiceInstanceBindingControllerIntegrationTest.java
@@ -180,7 +180,7 @@ public class ServiceInstanceBindingControllerIntegrationTest {
  	}
 	
 	@Test
-	public void unknownServiceInstanceBindingNotDeleted() throws Exception {
+	public void unknownServiceInstanceBindingNotDeletedAndA410IsReturned() throws Exception {
 	    ServiceInstance instance = ServiceInstanceFixture.getServiceInstance();
 	    ServiceInstanceBinding binding = ServiceInstanceBindingFixture.getServiceInstanceBinding();
 		
@@ -197,7 +197,7 @@ public class ServiceInstanceBindingControllerIntegrationTest {
 	    mockMvc.perform(delete(url)
 	    		.accept(MediaType.APPLICATION_JSON)
 	    	)
-	    	.andExpect(status().isNotFound())
+	    	.andExpect(status().isGone())
 	    	.andExpect(jsonPath("$", is("{}")));
  	}
 

--- a/src/test/java/org/cloudfoundry/community/servicebroker/controller/ServiceInstanceControllerIntegrationTest.java
+++ b/src/test/java/org/cloudfoundry/community/servicebroker/controller/ServiceInstanceControllerIntegrationTest.java
@@ -208,7 +208,7 @@ public class ServiceInstanceControllerIntegrationTest {
  	}
 	
 	@Test
-	public void deleteUnknownServiceInstanceFails() throws Exception {
+	public void deleteUnknownServiceInstanceFailsWithA410() throws Exception {
 	    ServiceInstance instance = ServiceInstanceFixture.getServiceInstance();
 			    
 		when(serviceInstanceService.deleteServiceInstance(any(String.class)))
@@ -221,7 +221,7 @@ public class ServiceInstanceControllerIntegrationTest {
 	    mockMvc.perform(delete(url)
 	    		.accept(MediaType.APPLICATION_JSON)
 	    	)
-	    	.andExpect(status().isNotFound())
+	    	.andExpect(status().isGone())
 	    	.andExpect(jsonPath("$", is("{}")));
  	}
 	


### PR DESCRIPTION
According to http://docs.cloudfoundry.org/services/api.html, an HTTP 410 (Gone) is returned from unbind and deprovision requests when the entity does not exist.
