### PR TITLE
Added ServiceInstance, the serviceId, and the planId to the deleteServiceInstanceBinding method.

### DIFF
--- a/src/main/java/org/cloudfoundry/community/servicebroker/controller/ServiceInstanceBindingController.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/controller/ServiceInstanceBindingController.java
@@ -81,13 +81,21 @@ public class ServiceInstanceBindingController extends BaseController {
 			@PathVariable("instanceId") String instanceId, 
 			@PathVariable("bindingId") String bindingId,
 			@RequestParam("service_id") String serviceId,
-			@RequestParam("plan_id") String planId) throws ServiceBrokerException {
+			@RequestParam("plan_id") String planId) throws ServiceBrokerException, ServiceInstanceDoesNotExistException {
 		logger.debug( "DELETE: " + BASE_PATH + "/{bindingId}"
 				+ ", deleteServiceInstanceBinding(),  serviceInstance.id = " + instanceId 
 				+ ", bindingId = " + bindingId 
 				+ ", serviceId = " + serviceId
 				+ ", planId = " + planId);
-		ServiceInstanceBinding binding = serviceInstanceBindingService.deleteServiceInstanceBinding(bindingId);
+        ServiceInstance instance = serviceInstanceService.getServiceInstance(instanceId);
+        if (instance == null) {
+            throw new ServiceInstanceDoesNotExistException(instanceId);
+        }
+		ServiceInstanceBinding binding = serviceInstanceBindingService.deleteServiceInstanceBinding(
+		        bindingId,
+		        instance,
+		        serviceId,
+		        planId);
 		if (binding == null) {
 			return new ResponseEntity<String>("{}", HttpStatus.GONE);
 		}

--- a/src/main/java/org/cloudfoundry/community/servicebroker/service/ServiceInstanceBindingService.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/service/ServiceInstanceBindingService.java
@@ -35,9 +35,13 @@ public interface ServiceInstanceBindingService {
 	/**
 	 * Delete the service instance binding.  If a binding doesn't exist, 
 	 * return null.
-	 * @param id 
+     * @param bindingId The id provided by the cloud controller
+     * @param serviceInstance The id of the service instance
+     * @param serviceId The id of the service
+     * @param planId The plan used for this binding
 	 * @return The deleted ServiceInstanceBinding or null if one does not exist.
 	 */
-	ServiceInstanceBinding deleteServiceInstanceBinding(String id) throws ServiceBrokerException;
+	ServiceInstanceBinding deleteServiceInstanceBinding(String bindingId, ServiceInstance instance, String serviceId, String planId) 
+	        throws ServiceBrokerException;
 	
 }


### PR DESCRIPTION
InstanceId, serviceId, and planId are all required on the Service Broker API for unbinding requests.  These should made available to the ServiceInstanceBindingService.deleteServiceInstanceBinding method along with the bindingId.  This is a breaking change on the ServiceInstanceBindingService interface.

I chose the method signature on ServiceInstanceBindingService.deleteServiceInstanceBinding and logic in the controller to stay consistent with the the bind operation.
