### PR TITLE
Added Spring Boot auto-configuration support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,12 @@ The configuration is all done through standard Spring mechanisms.  Feel free to 
 
 * BrokerConfig.java: This is required to ensure the `spring-boot-cf-service-broker` jar file is searched for auto wired dependencies.  You can also explicitly configure the controllers and services if you prefer.
 
-If you would like to disable service broker api version header verification, you can disable it by excluding the BrokerApiVersionConfig class in the @ComponentScan annotation:
+If you would like to disable service broker API version header verification, you can disable it by configuring a `BrokerApiVersion` bean that accepts any API version:
 
-	@ComponentScan(
-		basePackages = "org.cloudfoundry.community.servicebroker", 
-		excludeFilters= { 
-			@ComponentScan.Filter(
-				type=FilterType.ASSIGNABLE_TYPE, 
-				value=BrokerApiVersionConfig.class
-			)
-		}
-	)
+	@Bean
+	public BrokerApiVersion brokerApiVersion() {
+		return new BrokerApiVersion();
+	}
 
 You can also create your own filter if you would like behavior other than a simple version equality verification.
 

--- a/src/main/java/org/cloudfoundry/community/servicebroker/config/BrokerApiVersionConfig.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/config/BrokerApiVersionConfig.java
@@ -2,8 +2,7 @@ package org.cloudfoundry.community.servicebroker.config;
 
 import org.cloudfoundry.community.servicebroker.interceptor.BrokerApiVersionInterceptor;
 import org.cloudfoundry.community.servicebroker.model.BrokerApiVersion;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -11,17 +10,14 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 
 @Configuration
 @EnableWebMvc
-@ComponentScan(basePackages = "org.cloudfoundry.community.servicebroker")
 public class BrokerApiVersionConfig extends WebMvcConfigurerAdapter {
 
-	@Bean
-	public BrokerApiVersion brokerApiVersion() {
-		return new BrokerApiVersion("X-Broker-Api-Version","2.3");
-	}
+	@Autowired
+	private BrokerApiVersion brokerApiVersion;
 
 	@Override
-    public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new BrokerApiVersionInterceptor(brokerApiVersion())).addPathPatterns("/**");;
-    }
-	
-}	
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(new BrokerApiVersionInterceptor(brokerApiVersion)).addPathPatterns("/**");
+	}
+
+}

--- a/src/main/java/org/cloudfoundry/community/servicebroker/config/ServiceBrokerAutoConfiguration.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/config/ServiceBrokerAutoConfiguration.java
@@ -1,0 +1,33 @@
+package org.cloudfoundry.community.servicebroker.config;
+
+import org.cloudfoundry.community.servicebroker.model.BrokerApiVersion;
+import org.cloudfoundry.community.servicebroker.model.Catalog;
+import org.cloudfoundry.community.servicebroker.service.BeanCatalogService;
+import org.cloudfoundry.community.servicebroker.service.CatalogService;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan(basePackages = {"org.cloudfoundry.community.servicebroker"})
+@ConditionalOnWebApplication
+@AutoConfigureAfter(WebMvcAutoConfiguration.class)
+public class ServiceBrokerAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean(BrokerApiVersion.class)
+	public BrokerApiVersion brokerApiVersion() {
+		return new BrokerApiVersion("2.3");
+	}
+
+	@Bean
+	@ConditionalOnMissingBean(CatalogService.class)
+	public CatalogService beanCatalogService(Catalog catalog) {
+		return new BeanCatalogService(catalog);
+	}
+
+}

--- a/src/main/java/org/cloudfoundry/community/servicebroker/interceptor/BrokerApiVersionInterceptor.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/interceptor/BrokerApiVersionInterceptor.java
@@ -5,25 +5,23 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.cloudfoundry.community.servicebroker.exception.ServiceBrokerApiVersionException;
 import org.cloudfoundry.community.servicebroker.model.BrokerApiVersion;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
-@Component
 public class BrokerApiVersionInterceptor extends HandlerInterceptorAdapter {
-	
-	@Autowired(required = false)
-	private BrokerApiVersion version;
-	
-	public BrokerApiVersionInterceptor() {}
-	
+
+	private final BrokerApiVersion version;
+
+	public BrokerApiVersionInterceptor() {
+		this(null);
+	}
+
 	public BrokerApiVersionInterceptor(BrokerApiVersion version) {
 		this.version = version;
 	}
-	
+
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
-			Object handler) throws ServiceBrokerApiVersionException {	
-		if (version != null) {
+			Object handler) throws ServiceBrokerApiVersionException {
+		if (version != null && !anyVersionAllowed()) {
 			String apiVersion = request.getHeader(version.getBrokerApiVersionHeader());
 			if (!version.getApiVersion().equals(apiVersion)) {
 				throw new ServiceBrokerApiVersionException(version.getApiVersion(), apiVersion);
@@ -31,5 +29,9 @@ public class BrokerApiVersionInterceptor extends HandlerInterceptorAdapter {
 		}
 		return true;
 	}
-	
+
+	private boolean anyVersionAllowed() {
+		return BrokerApiVersion.API_VERSION_ANY.equals(version.getApiVersion());
+	}
+
 }

--- a/src/main/java/org/cloudfoundry/community/servicebroker/model/BrokerApiVersion.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/model/BrokerApiVersion.java
@@ -3,20 +3,31 @@ package org.cloudfoundry.community.servicebroker.model;
 
 public class BrokerApiVersion {
 
+	public final static String DEFAULT_API_VERSION_HEADER = "X-Broker-Api-Version";
+	public final static String API_VERSION_ANY = "*";
+
 	private String brokerApiVersionHeader;
 	private String apiVersion;
-	
+
 	public BrokerApiVersion(String brokerApiVersionHeader, String apiVersion) {
 		this.brokerApiVersionHeader = brokerApiVersionHeader;
 		this.apiVersion = apiVersion;
 	}
-	
+
+	public BrokerApiVersion(String apiVersion) {
+		this(DEFAULT_API_VERSION_HEADER, apiVersion);
+	}
+
+	public BrokerApiVersion() {
+		this(DEFAULT_API_VERSION_HEADER, API_VERSION_ANY);
+	}
+
 	public String getBrokerApiVersionHeader() {
 		return brokerApiVersionHeader;
 	}
-	
+
 	public String getApiVersion() {
 		return apiVersion;
 	}
-	
+
 }

--- a/src/main/java/org/cloudfoundry/community/servicebroker/service/BeanCatalogService.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/service/BeanCatalogService.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Service;
  * @author sgreenberg@gopivotal.com
  *
  */
-@Service
 public class BeanCatalogService implements CatalogService {
 
 	private Catalog catalog;

--- a/src/main/java/org/cloudfoundry/community/servicebroker/service/ServiceInstanceService.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/service/ServiceInstanceService.java
@@ -35,7 +35,7 @@ public interface ServiceInstanceService {
 			throws ServiceInstanceExistsException, ServiceBrokerException;
 	
 	/**
-	 * @param id
+	 * @param id The id of the serviceInstance
 	 * @return The ServiceInstance with the given id or null if one does not exist
 	 */
 	ServiceInstance getServiceInstance(String id);

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.cloudfoundry.community.servicebroker.config.ServiceBrokerAutoConfiguration

--- a/src/test/java/org/cloudfoundry/community/servicebroker/interceptor/BrokerApiVersionInterceptorTest.java
+++ b/src/test/java/org/cloudfoundry/community/servicebroker/interceptor/BrokerApiVersionInterceptorTest.java
@@ -1,6 +1,7 @@
 package org.cloudfoundry.community.servicebroker.interceptor;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -27,7 +28,7 @@ public class BrokerApiVersionInterceptorTest {
 	
 	@Mock
 	private BrokerApiVersion brokerApiVersion;
-	
+
 	@Before
 	public void setup() {
 		MockitoAnnotations.initMocks(this);
@@ -38,21 +39,33 @@ public class BrokerApiVersionInterceptorTest {
 		BrokerApiVersionInterceptor interceptor = new BrokerApiVersionInterceptor(null);
 		assertTrue(interceptor.preHandle(request, response, null));
 	}
-	
+
 	@Test
-	public void versionsCorrect() throws IOException, ServletException, ServiceBrokerApiVersionException {
+	public void anyVersionAccepted() throws IOException, ServletException, ServiceBrokerApiVersionException {
+		String header = "header";
+		String version = BrokerApiVersion.API_VERSION_ANY;
+		when(brokerApiVersion.getBrokerApiVersionHeader()).thenReturn(header);
+		when(brokerApiVersion.getApiVersion()).thenReturn(version);
+		when(request.getHeader(header)).thenReturn("version");
+		
+		BrokerApiVersionInterceptor interceptor = new BrokerApiVersionInterceptor(brokerApiVersion);
+		assertTrue(interceptor.preHandle(request, response, null));
+		verify(brokerApiVersion, atLeastOnce()).getApiVersion();
+	}
+
+	@Test
+	public void versionsMatch() throws IOException, ServletException, ServiceBrokerApiVersionException {
 		String header = "header";
 		String version = "version";
 		when(brokerApiVersion.getBrokerApiVersionHeader()).thenReturn(header);
 		when(brokerApiVersion.getApiVersion()).thenReturn(version);
 		when(request.getHeader(header)).thenReturn(version);
-		
+
 		BrokerApiVersionInterceptor interceptor = new BrokerApiVersionInterceptor(brokerApiVersion);
 		assertTrue(interceptor.preHandle(request, response, null));
-		verify(brokerApiVersion).getBrokerApiVersionHeader();
-		verify(brokerApiVersion).getApiVersion();
+		verify(brokerApiVersion, atLeastOnce()).getApiVersion();
 	}
-	
+
 	@Test(expected = ServiceBrokerApiVersionException.class)
 	public void versionMismatch() throws IOException, ServletException, ServiceBrokerApiVersionException {
 		String header = "header";


### PR DESCRIPTION
This commit adds Spring Boot style auto configuration. With this change, an app using `spring-boot-cf-service-broker` can use `@EnableAutoConfiguration` to enable component scanning of `spring-boot-cf-service-broker` components without having to add a `@ComponentScan` annotation containing the `spring-boot-cf-service-broker` package. 

This also eliminates the need to exclude beans like `BrokerApiVersionConfig` and `BeanCatalogService` when the app wants to override with their own behavior. `spring-boot-cf-service-broker` will provide default versions of these beans if the app doesn't provide one, or back off if the app does provide its own beans. 
