### PR TITLE
Support for changing the service plan for a specified service instance

### DIFF
--- a/src/main/java/org/cloudfoundry/community/servicebroker/exception/ServiceInstanceUpdateNotSupportedException.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/exception/ServiceInstanceUpdateNotSupportedException.java
@@ -1,0 +1,23 @@
+package org.cloudfoundry.community.servicebroker.exception;
+
+/**
+ * May be thrown if the particular plan change requested is not supported or if the request 
+ * can not currently be fulfilled due to the state of the instance
+ */
+public class ServiceInstanceUpdateNotSupportedException extends Exception {
+
+	private static final long serialVersionUID = 4719676639792071582L;
+
+	public ServiceInstanceUpdateNotSupportedException(String message) {
+		super(message);
+	}
+
+	public ServiceInstanceUpdateNotSupportedException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public ServiceInstanceUpdateNotSupportedException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/src/main/java/org/cloudfoundry/community/servicebroker/model/ServiceDefinition.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/model/ServiceDefinition.java
@@ -5,10 +5,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
@@ -40,7 +40,11 @@ public class ServiceDefinition {
 	@JsonSerialize
 	@JsonProperty("bindable")
 	private boolean bindable;
-	
+
+	@JsonSerialize
+	@JsonProperty("plan_updateable")
+	private boolean planUpdateable;
+
 	@NotEmpty
 	@JsonSerialize
 	@JsonProperty("plans")
@@ -73,12 +77,14 @@ public class ServiceDefinition {
 		this.setPlans(plans);
 	}
 
-	public ServiceDefinition(String id, String name, String description, boolean bindable, List<Plan> plans,
-			List<String> tags, Map<String,Object> metadata, List<String> requires, DashboardClient dashboardClient) {
+	public ServiceDefinition(String id, String name, String description, boolean bindable, boolean planUpdatable, 
+			List<Plan> plans, List<String> tags, Map<String,Object> metadata, List<String> requires, 
+			DashboardClient dashboardClient) {
 		this(id, name, description, bindable, plans);
 		setTags(tags);
 		setMetadata(metadata);
 		setRequires(requires);
+		setPlanUpdatable(planUpdatable);
 		this.dashboardClient = dashboardClient;
 	}
 	
@@ -96,6 +102,14 @@ public class ServiceDefinition {
 
 	public boolean isBindable() {
 		return bindable;
+	}
+
+	public boolean isPlanUpdatable() {
+		return planUpdateable;
+	}
+
+	public void setPlanUpdatable(boolean planUpdatable) {
+		this.planUpdateable = planUpdatable;
 	}
 
 	public List<Plan> getPlans() {

--- a/src/main/java/org/cloudfoundry/community/servicebroker/model/ServiceUpdateInstanceRequest.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/model/ServiceUpdateInstanceRequest.java
@@ -1,0 +1,37 @@
+package org.cloudfoundry.community.servicebroker.model;
+
+import org.hibernate.validator.constraints.NotEmpty;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * A request sent by the cloud controller to update an instance of a service.
+ * 
+ */
+@JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ServiceUpdateInstanceRequest {
+
+	@NotEmpty
+	@JsonSerialize
+	@JsonProperty("plan_id")
+	private String planId;
+
+	public ServiceUpdateInstanceRequest() {}
+
+	public ServiceUpdateInstanceRequest(String planId) {
+		this.planId = planId;
+	}
+
+	public String getPlanId() {
+		return planId;
+	}
+
+	public void setPlanId(String planId) {
+		this.planId = planId;
+	}
+
+}

--- a/src/main/java/org/cloudfoundry/community/servicebroker/service/ServiceInstanceService.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/service/ServiceInstanceService.java
@@ -1,7 +1,9 @@
 package org.cloudfoundry.community.servicebroker.service;
 
 import org.cloudfoundry.community.servicebroker.exception.ServiceBrokerException;
+import org.cloudfoundry.community.servicebroker.exception.ServiceInstanceDoesNotExistException;
 import org.cloudfoundry.community.servicebroker.exception.ServiceInstanceExistsException;
+import org.cloudfoundry.community.servicebroker.exception.ServiceInstanceUpdateNotSupportedException;
 import org.cloudfoundry.community.servicebroker.model.ServiceDefinition;
 import org.cloudfoundry.community.servicebroker.model.ServiceInstance;
 
@@ -42,5 +44,21 @@ public interface ServiceInstanceService {
 	 * @throws ServiceBrokerException is something goes wrong internally
 	 */
 	ServiceInstance deleteServiceInstance(String id, String serviceId, String planId) throws ServiceBrokerException;
-	
+
+	/**
+	 * Update a service instance. Only modification of service plan is supported.
+	 * 
+	 * @param instanceId
+	 * @param planId
+	 * @return null if modification succeeded
+	 * @throws ServiceInstanceUpdateNotSupportedException if particular plan change is not supported
+	 *         or if the request can not currently be fulfilled due to the state of the instance.
+	 * @throws ServiceInstanceDoesNotExistException if the service instance does not exist
+	 * @throws ServiceBrokerException if something goes wrong internally
+	 * 
+	 */
+	ServiceInstance updateServiceInstance(String instanceId, String planId)
+			throws ServiceInstanceUpdateNotSupportedException, ServiceBrokerException,
+			ServiceInstanceDoesNotExistException;
+
 }

--- a/src/test/java/org/cloudfoundry/community/servicebroker/model/fixture/ServiceInstanceFixture.java
+++ b/src/test/java/org/cloudfoundry/community/servicebroker/model/fixture/ServiceInstanceFixture.java
@@ -8,6 +8,7 @@ import org.cloudfoundry.community.servicebroker.model.CreateServiceInstanceReque
 import org.cloudfoundry.community.servicebroker.model.CreateServiceInstanceResponse;
 import org.cloudfoundry.community.servicebroker.model.ServiceDefinition;
 import org.cloudfoundry.community.servicebroker.model.ServiceInstance;
+import org.cloudfoundry.community.servicebroker.model.ServiceUpdateInstanceRequest;
 
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -62,5 +63,16 @@ public class ServiceInstanceFixture {
 	public static CreateServiceInstanceResponse getCreateServiceInstanceResponse() {
 		return new CreateServiceInstanceResponse(getServiceInstance());
 	}
+
+	public static String getUpdateServiceInstanceRequestJson() throws JsonGenerationException,
+	JsonMappingException, IOException {
+		return DataFixture.toJson(getUpdateServiceInstanceRequest());
+	}
 	
+	public static ServiceUpdateInstanceRequest getUpdateServiceInstanceRequest() {
+		ServiceDefinition service = ServiceFixture.getService();
+		return new ServiceUpdateInstanceRequest(service.getPlans().get(0).getId());
+	}
+
+
 }


### PR DESCRIPTION
Hi, Server Broker API introduced new functionality in v2.4 API - support for users to change the service plan for a specified service instance. This is the implementation + tests. Please review.
