### PR TITLE
Adding JPA annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+		mavenLocal()
         mavenCentral()
     }
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 buildscript {
     repositories {
-        mavenLocal()
         mavenCentral()
     }
     dependencies {
@@ -14,7 +13,7 @@ apply plugin: 'idea'
 apply plugin: 'spring-boot'
 apply plugin: 'maven-publish'
 
-version = "2.4.0"
+version = "2.4.1"
 group = "org.cloudfoundry"
 description = "Spring Boot project for creating Cloud Foundry service brokers"
 
@@ -50,6 +49,7 @@ repositories {
 dependencies {
     compile("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
     compile("org.springframework.boot:spring-boot-starter-security:${springBootVersion}")
+	compile("org.springframework.boot:spring-boot-starter-data-jpa:${springBootVersion}")
     compile("org.hibernate:hibernate-validator:${hibernateValidatorVersion}")
 
     testCompile("org.springframework.boot:spring-boot-starter-test:${springBootVersion}")

--- a/src/main/java/org/cloudfoundry/community/servicebroker/config/BrokerApiVersionConfig.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/config/BrokerApiVersionConfig.java
@@ -17,7 +17,7 @@ public class BrokerApiVersionConfig extends WebMvcConfigurerAdapter {
 
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
-		registry.addInterceptor(new BrokerApiVersionInterceptor(brokerApiVersion)).addPathPatterns("/**");
+		registry.addInterceptor(new BrokerApiVersionInterceptor(brokerApiVersion)).addPathPatterns("/v2/**");
 	}
 
 }

--- a/src/main/java/org/cloudfoundry/community/servicebroker/model/ServiceInstance.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/model/ServiceInstance.java
@@ -1,5 +1,9 @@
 package org.cloudfoundry.community.servicebroker.model;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -11,29 +15,36 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
  * @author sgreenberg@gopivotal.com
  *
  */
+@Entity
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
 public class ServiceInstance {
 
+	@Id
 	@JsonSerialize
 	@JsonProperty("service_instance_id")
 	private String id;
 	
+	@Column
 	@JsonSerialize
 	@JsonProperty("service_id")
 	private String serviceDefinitionId;
 	
+	@Column
 	@JsonSerialize
 	@JsonProperty("plan_id")
 	private String planId;
 	
+	@Column
 	@JsonSerialize
 	@JsonProperty("organization_guid")
 	private String organizationGuid;
 	
+	@Column
 	@JsonSerialize
 	@JsonProperty("space_guid")
 	private String spaceGuid;
 	
+	@Column
 	@JsonSerialize
 	@JsonProperty("dashboard_url")
 	private String dashboardUrl;

--- a/src/main/java/org/cloudfoundry/community/servicebroker/model/ServiceInstanceBinding.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/model/ServiceInstanceBinding.java
@@ -3,23 +3,41 @@ package org.cloudfoundry.community.servicebroker.model;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.validation.constraints.NotNull;
+
 /**
  * A binding to a service instance
  * 
  * @author sgreenberg@gopivotal.com
  *
  */
+@Entity
 public class ServiceInstanceBinding {
 
+	@Id
 	private String id;
+	@Column
+	@NotNull
 	private String serviceInstanceId;
-	private Map<String,Object> credentials = new HashMap<String,Object>();
+	@ElementCollection(fetch=FetchType.EAGER)
+	private Map<String,String> credentials = new HashMap<>();
+	@Column
 	private String syslogDrainUrl;
+	@Column
 	private String appGuid;
+	
+	public ServiceInstanceBinding() {
+		
+	}
 
 	public ServiceInstanceBinding(String id, 
 			String serviceInstanceId, 
-			Map<String,Object> credentials,
+			Map<String,String> credentials,
 			String syslogDrainUrl, String appGuid) {
 		this.id = id;
 		this.serviceInstanceId = serviceInstanceId;
@@ -31,18 +49,26 @@ public class ServiceInstanceBinding {
 	public String getId() {
 		return id;
 	}
+	
+	public void setId(String id) {
+		this.id = id;
+	}
 
 	public String getServiceInstanceId() {
 		return serviceInstanceId;
 	}
+	
+	public void setServiceInstanceId(String id) {
+		this.serviceInstanceId = id;
+	}
 
-	public Map<String, Object> getCredentials() {
+	public Map<String, String> getCredentials() {
 		return credentials;
 	}
 
-	private void setCredentials(Map<String, Object> credentials) {
+	private void setCredentials(Map<String, String> credentials) {
 		if (credentials == null) {
-			credentials = new HashMap<String,Object>();
+			credentials = new HashMap<String,String>();
 		} else {
 			this.credentials = credentials;
 		}
@@ -52,8 +78,16 @@ public class ServiceInstanceBinding {
 		return syslogDrainUrl;
 	}
 	
+	public void setSyslogDrainUrl(String url) {
+		this.syslogDrainUrl = url;
+	}
+	
 	public String getAppGuid() {
 		return appGuid;
+	}
+	
+	public void setAppGuid(String uid) {
+		this.appGuid = uid;
 	}
 	
 }

--- a/src/main/java/org/cloudfoundry/community/servicebroker/model/ServiceInstanceBindingResponse.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/model/ServiceInstanceBindingResponse.java
@@ -1,8 +1,10 @@
 package org.cloudfoundry.community.servicebroker.model;
 
+import java.io.Serializable;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import org.hibernate.validator.constraints.NotEmpty;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
@@ -30,7 +32,7 @@ public class ServiceInstanceBindingResponse {
 	@NotEmpty
 	@JsonSerialize
 	@JsonProperty("credentials")
-	public Map<String, Object> getCredentials() {
+	public Map<String, String> getCredentials() {
 		return binding.getCredentials();
 	}
 

--- a/src/test/java/org/cloudfoundry/community/servicebroker/model/fixture/ServiceInstanceBindingFixture.java
+++ b/src/test/java/org/cloudfoundry/community/servicebroker/model/fixture/ServiceInstanceBindingFixture.java
@@ -29,8 +29,8 @@ public class ServiceInstanceBindingFixture {
 		return "service_instance_binding_id";
 	}
 	
-	public static Map<String,Object> getCredentials() {
-		Map<String,Object> credentials = new HashMap<String,Object>();
+	public static Map<String,String> getCredentials() {
+		Map<String,String> credentials = new HashMap<String,String>();
 		credentials.put("uri","uri");
 		credentials.put("username", "username");
 		credentials.put("password", "password");


### PR DESCRIPTION
Adding JPA annotations to ServiceInstance and ServiceInstanceBinding so they can be stored in JPA repository in case there is no mongoDB available to store these. So it should be possible to store these in a JPA repository (hsqldb, mysql, etc) or a mongo repository.

Also, moved version to 2.4.1.